### PR TITLE
fix Coreos operating system identifier

### DIFF
--- a/app/models/foreman_fog_proxmox/proxmox_operating_systems.rb
+++ b/app/models/foreman_fog_proxmox/proxmox_operating_systems.rb
@@ -39,7 +39,7 @@ module ForemanFogProxmox
     end
 
     def os_linux_types_mapping(host)
-      ['Debian', 'Redhat', 'Suse', 'Altlinux', 'Archlinux', 'CoreOs', 'Gentoo'].include?(host.operatingsystem.type) ? available_linux_operating_systems : []
+      ['Debian', 'Redhat', 'Suse', 'Altlinux', 'Archlinux', 'Coreos', 'Gentoo'].include?(host.operatingsystem.type) ? available_linux_operating_systems : []
     end
 
     def os_windows_types_mapping(host)


### PR DESCRIPTION
This is intended to fix the following error:

`Failed to create a compute italab-proxmox (Proxmox) instance neil-trimboli.test.spock.bmwgroup.net: ERF42-0326 [Foreman::Exception]: Operating system family Coreos is not consistent with l26`